### PR TITLE
heading -> headings for route Post Request

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -2553,7 +2553,7 @@ components:
           default: fastest
           description: |
             Determines the way the ''best'' route is calculated. Default is `fastest`. Other options are `shortest` (e.g. for `vehicle=foot` or `bike`) and `short_fastest` which finds a reasonable balance between `shortest` and `fastest`. Requires `ch.disable=true`.
-        heading:
+        headings:
           type: array
           items:
             type: integer


### PR DESCRIPTION
The post parameter name is "heading**s**" (plural) not "heading" (singular) but the docs list it as singular.
This pull request should change it to plural in the description but I wasn't sure how to change the example to plural.

<img width="257" alt="Screen Shot 2020-09-08 at 12 50 59 PM" src="https://user-images.githubusercontent.com/25244432/92508619-f1c90580-f1d6-11ea-8aee-f671089bd142.png">

<img width="558" alt="Screen Shot 2020-09-08 at 12 51 09 PM" src="https://user-images.githubusercontent.com/25244432/92508631-f4c3f600-f1d6-11ea-9172-7c3b72da5861.png">
 